### PR TITLE
Fix new cmake warnings in 2.5.0

### DIFF
--- a/master/Dockerfile
+++ b/master/Dockerfile
@@ -27,6 +27,7 @@ RUN set -x && \
         qt5-qtbase-dev \
         qt5-qtsvg-dev \
         qt5-qttools-dev \
+        qt5-qtx11extras-dev \
         zlib-dev && \
     git clone --depth 1 --branch ${KEEPASSXC_VERSION} https://github.com/keepassxreboot/keepassxc.git /usr/src/keepassxc && \
     cd /usr/src/keepassxc && \
@@ -37,7 +38,6 @@ RUN set -x && \
         -DKEEPASSXC_BUILD_TYPE=Release \
         -DWITH_TESTS=OFF \
         -DWITH_XC_AUTOTYPE=ON \
-        -DWITH_XC_HTTP=ON \
         -DWITH_XC_KEESHARE=OFF \
         -DWITH_XC_YUBIKEY=OFF \
         .. && \

--- a/stable/Dockerfile
+++ b/stable/Dockerfile
@@ -27,6 +27,7 @@ RUN set -x && \
         qt5-qtbase-dev \
         qt5-qtsvg-dev \
         qt5-qttools-dev \
+        qt5-qtx11extras-dev \
         zlib-dev && \
     git clone --depth 1 --branch ${KEEPASSXC_VERSION} https://github.com/keepassxreboot/keepassxc.git /usr/src/keepassxc && \
     cd /usr/src/keepassxc && \
@@ -37,7 +38,6 @@ RUN set -x && \
         -DKEEPASSXC_BUILD_TYPE=Release \
         -DWITH_TESTS=OFF \
         -DWITH_XC_AUTOTYPE=ON \
-        -DWITH_XC_HTTP=ON \
         -DWITH_XC_KEESHARE=OFF \
         -DWITH_XC_YUBIKEY=OFF \
         .. && \


### PR DESCRIPTION
Remove the following warnings when building:
```
CMake Warning at src/autotype/CMakeLists.txt:4 (find_package):
  By not providing "FindQt5X11Extras.cmake" in CMAKE_MODULE_PATH this project
  has asked CMake to find a package configuration file provided by
  "Qt5X11Extras", but CMake did not find one.

  Could not find a package configuration file provided by "Qt5X11Extras"
  (requested version 5.2) with any of the following names:

    Qt5X11ExtrasConfig.cmake
    qt5x11extras-config.cmake

  Add the installation prefix of "Qt5X11Extras" to CMAKE_PREFIX_PATH or set
  "Qt5X11Extras_DIR" to a directory containing one of the above files.  If
  "Qt5X11Extras" provides a separate development package or SDK, be sure it
  has been installed.
```
and
```
CMake Warning:
  Manually-specified variables were not used by the project:

    WITH_XC_HTTP
```